### PR TITLE
Updates needed for core20 and gnome-3-38

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ name: gnome-robots
 adopt-info: gnome-robots
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict
-base: core18
+base: core20
 
 slots:
   # for GtkApplication registration
@@ -13,49 +13,15 @@ slots:
 
 apps:
   gnome-robots:
-    extensions: [gnome-3-34]
+    extensions: [gnome-3-38]
     command: usr/bin/gnome-robots
     plugs:
-      - gsettings
-      - pulseaudio
+      - audio-playback
     desktop: usr/share/applications/org.gnome.Robots.desktop
     common-id: org.gnome.Robots.desktop
 
 parts:
-  libcanberra:
-    source: git://git.0pointer.de/libcanberra
-    source-type: git
-    plugin: autotools
-    configflags:
-      - --prefix=/snap/gnome-robots/current/usr
-      - --enable-pulse
-      - --enable-gstreamer
-      - --enable-gtk3
-      - --enable-alsa
-      - --disable-oss
-    organize:
-      snap/gnome-robots/current/usr: usr
-    build-packages:
-      - libltdl-dev
-      - libasound2-dev
-      - libvorbis-dev
-      - libgtk-3-dev
-      - libtdb-dev
-      - libpulse-dev
-      - libgstreamer1.0-dev
-      - libudev-dev
-      - gtk-doc-tools
-
-  libgnome-games-support:
-    source: https://gitlab.gnome.org/GNOME/libgnome-games-support.git
-    source-type: git
-    plugin: meson
-    meson-parameters: [--prefix=/usr]
-    organize:
-      snap/gnome-2048/current/usr: usr
-
   gnome-robots:
-    after: [libcanberra, libgnome-games-support]
     source: https://gitlab.gnome.org/GNOME/gnome-robots.git
     source-type: git
     source-tag: '40.0'
@@ -63,7 +29,7 @@ parts:
       snapcraftctl pull
       snapcraftctl set-version $(git describe --tags --abbrev=10)
     override-build: |
-      sed -i.bak -e 's|=org.gnome.Robots$|=${SNAP}/meta/gui/org.gnome.Robots.svg|g' data/org.gnome.Robots.desktop.in
+      sed -i.bak -e 's|=org.gnome.Robots$|=${SNAP}/meta/gui/org.gnome.Robots.svg|g' $SNAPCRAFT_PART_SRC/data/org.gnome.Robots.desktop.in
       snapcraftctl build
       mkdir -p $SNAPCRAFT_PART_INSTALL/meta/gui/
       cp ../src/data/icons/hicolor/scalable/org.gnome.Robots.svg $SNAPCRAFT_PART_INSTALL/meta/gui/
@@ -72,23 +38,3 @@ parts:
     parse-info: [usr/share/metainfo/org.gnome.Robots.appdata.xml]
     organize:
       snap/gnome-robots/current/usr: usr
-    build-packages:
-      - appstream-util
-      - gettext
-      - intltool
-      - libglib2.0-dev
-      - libgnome-games-support-1-dev
-      - libgsound-dev
-      - libgtk-3-dev
-      - librsvg2-dev
-      - yelp-tools
-
-  libraries:
-    plugin: nil
-    stage-packages:
-      - libgee-0.8-2
-      - libgsound0
-    prime:
-      - "usr/lib/*/libgnome-games-support-1.so.*"
-      - "usr/lib/*/libgee-0.8.so.*"
-      - "usr/lib/*/libgsound.so.*"


### PR DESCRIPTION
## Description

Updated to core20 and gnome-3-38 extension.
This is a re-opening of #1 

## Type of change

Please check only the options that are relevant.

- [x] General Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I built the snap locally, installed it locally, launched it from the desktop icon in Activites and it looks good.

snapcraft (latest/edge): 7.0.post6+gitc94bee07
OS: 22.04

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

